### PR TITLE
merge is_forwarded into device_pool

### DIFF
--- a/mtbf_job_runner.py
+++ b/mtbf_job_runner.py
@@ -3,11 +3,9 @@
 import os
 import sys
 import logging
-import subprocess
 import shutil
 import stat
 import glob
-import re
 import tempfile
 import utils.crash_scan as CrashScan
 from combo_runner import action_decorator
@@ -97,11 +95,11 @@ class MtbfJobRunner(BaseActionRunner):
             os.system("fastboot oem mem " + mem_str)
             # Preventing from async timing of fastboot
             os.system("fastboot reboot")
-            self.port_forwarding(self.serial, self.port)
+            self.device_obj.create_adb_forward(self.port)
             return True
         logger.error("Can't find device")
         self.marionette.wait_for_port()
-        self.port_forwarding(self.serial, self.port)
+        self.device_obj.create_adb_forward(self.port)
         return False
 
     @action(enabled=True)
@@ -110,28 +108,16 @@ class MtbfJobRunner(BaseActionRunner):
 
     def get_free_device(self):
         dp = DevicePool(self.serial)
-        if dp and dp.get_lock():
+        self.dp = dp
+        do = dp.get_device()
+        if dp and do:
             # Record device serial and store dp instance
-            self.serial = str(dp)
-            self.dp = dp
-            device_is_not_in_fowarded = False
-            for retry in range(3):
-                if self.is_forwarded(self.serial):
-                    # device is forwarded before acquired; stop and avoid possible error
-                    dp.get_next_lock()
-                    self.serial = str(dp)
-                else:
-                    device_is_not_in_fowarded = True
-                    break
-            if device_is_not_in_fowarded is False:
-                self.serial = None
-                raise DMError("Device already in forwarding list")
-
-            os.environ["ANDROID_SERIAL"] = self.serial
-            self.port = self.find_available_port()
-            if self.port_forwarding(str(dp), self.port):
+            self.serial = do.serial
+            self.device_obj = do
+            if do.create_adb_forward():
+                self.port = do.adb_forwarded_port
                 logger.info("Device found, ANDROID_SERIAL= " + self.serial)
-                return dp
+                return do
             logger.error("Port forwarding failed")
             raise DMError
         logger.warning("No available device.  Please retry after device released")
@@ -228,43 +214,6 @@ class MtbfJobRunner(BaseActionRunner):
         self.flashed = True
         os.system("ANDROID_SERIAL=" + self.serial + " adb wait-for-device")
 
-    def is_forwarded(self, serial):
-        out = subprocess.check_output(['/usr/bin/adb version'], shell=True)
-        search = re.search('[0-9\.]+', out)
-        os.system("ANDROID_SERIAL=" + self.serial + " adb wait-for-device")
-        if search and search.group(0) >= '1.0.31':
-            forward_list = subprocess.check_output('/usr/bin/adb forward --list', shell=True).splitlines()
-            for out in forward_list:
-                search_serial = re.search('\w+', out)
-                if search_serial and search_serial.group(0) == serial:
-                    logger.info("DeviceSerial[" + serial + "] forwarded")
-                    return int(re.search(' tcp:(\d+) ', out).group(1))
-        else:
-            logger.info("adb forward --list not supported; recommend to upgrade 1.0.31 or newer version")
-        return None
-
-    def port_forwarding(self, serial, port):
-        has_port = self.is_forwarded(serial)
-        if has_port:
-            logger.info("Using existing port [" + str(self.port) + "]")
-            self.port = has_port
-            return True
-        if serial and port:
-            ret = os.system("ANDROID_SERIAL=" + serial + " adb forward tcp:" + str(port) + " tcp:2828")
-            if ret != 0:
-                raise DMError("can't forward port to ANDROID_SERIAL[" + serial + "]")
-        logger.info("Port forwarding success serial:[" + serial + "] port:[" + str(port) + "]")
-        return True
-
-    def find_available_port(self):
-        if 'ANDROID_SERIAL' in os.environ.keys():
-            import socket
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.bind(('', 0))
-            port = sock.getsockname()[1]
-            sock.close()
-            return port
-
     @action(enabled=True)
     def enable_certified_apps_debug(self):
         if self.serial:
@@ -276,15 +225,6 @@ class MtbfJobRunner(BaseActionRunner):
     def release(self):
         if hasattr(self, 'dp') and self.dp:
             self.dp.release()
-            if self.serial:
-                port = self.is_forwarded(self.serial)
-                if port:
-                # Remove port forwarding
-                    os.system("ADNDROID_SERIAL=" + self.serial + " adb forward --remove tcp:" + str(port))
-            return True
-        else:
-            logger.warning("No device allocated")
-            return False
 
     def check_version(self):
         # FIXME: fix check version to use package import
@@ -401,7 +341,7 @@ class MtbfJobRunner(BaseActionRunner):
                 self.mtbf_options()
                 self.pre_flash()
                 self.flash()
-                self.port_forwarding(self.serial, self.port)
+                self.device_obj.create_adb_forward()
                 self.post_flash()
                 self.execute()
                 self.collect_report(self.serial)

--- a/utils/device_pool.py
+++ b/utils/device_pool.py
@@ -1,107 +1,196 @@
 #!/usr/bin/env python
-from lockfile import LockFile, NotLocked
 import os
 import logging
 import subprocess
+import re
+import socket
 
+from mozdevice.devicemanager import DMError
+from lockfile import LockFile, NotLocked
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-class DevicePool(object):
-    lock_folder = "/tmp/LOCKS"
-    my_lock = None
-    serial = None
-    current_lock_index = -1
+class DeviceObject(object):
+    lock_file_folder = "/tmp/LOCKS"
 
-    def __init__(self, deviceSerial=None):
-        self.devices = self._device_list()
-        if deviceSerial:
-            self.serial = deviceSerial
-            self._check_serial_in_devices()
-        if not os.path.exists(self.lock_folder):
-            os.makedirs(self.lock_folder)
-        self.lock_list = self._get_lock_list()
-
-    def _check_serial_in_devices(self):
-        if self.serial:
-            chk_list = filter(lambda x: x == self.serial, self.devices)
-            if not chk_list:
-                logger.warning("Android serial[" + self.serial + "] can't be found")
-                return False
-            else:
-                return True
-
-    def _device_list(self):
-        # adb devices here
-        device_list = subprocess.check_output(['adb', 'devices']).splitlines()
-        device_list.pop(0)  # remove the description from adb
-        device_list = map(lambda x: x.split("\t")[0], filter(lambda x: x, device_list))
-        return device_list
-
-    def _lock_list(self):
-        return map(lambda x: x.split(".")[0],
-                   filter(lambda x: 'lock' in x,
-                          subprocess.check_output(['ls', self.lock_folder]).splitlines()))
-
-    def _get_lock_list(self):
-        lock_list = []
-        for device in self.devices:
-            lock_path = os.path.join(self.lock_folder, device)
-            lock_list.append(LockFile(lock_path))
-        return lock_list
+    def __init__(self, serial):
+        self.serial = serial
+        self.lock_file_path = None
+        self.lock_file = None
+        self.adb_forwarded_port = None
+        self._gen_lock_file_from_serial()
 
     def __str__(self):
-        if self.my_lock:
-            return os.path.basename(self.my_lock.path).split('.')[0]
-        return ''
+        return self.serial
 
-    def get_lock(self):
-        if self.my_lock:
-            return self.my_lock
-        # TODO: acquire another lock to ensure critical section (?) test if it is necessary
-        for index in range(len(self.lock_list)):
+    def _gen_lock_file_from_serial(self):
+        if not os.path.exists(self.lock_file_folder):
+            os.makedirs(self.lock_file_folder)
+        self.lock_file_path = os.path.join(self.lock_file_folder, self.serial)
+        self.lock_file = LockFile(self.lock_file_path)
+        return self.lock_file
+
+    def _gen_serial_from_lock(self):
+        self.serial = os.path.basename(self.lock_file.path).split('.')[0]
+        return self.serial
+
+    def _find_available_port(self):
+        os.environ["ANDROID_SERIAL"] = self.serial
+        if 'ANDROID_SERIAL' in os.environ.keys():
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.bind(('', 0))
+            port = sock.getsockname()[1]
+            sock.close()
+            return port
+
+    def is_file_locked(self):
+        return self.lock_file.i_am_locking()
+
+    def is_in_forwarded_list(self):
+        out = subprocess.check_output(['/usr/bin/adb version'], shell=True)
+        search = re.search('[0-9\.]+', out)
+        os.system("ANDROID_SERIAL=" + self.serial + " adb wait-for-device")
+        if search and search.group(0) >= '1.0.31':
+            ret = subprocess.call('/usr/bin/adb forward --list |grep ' + self.serial, shell=True, stdout=open(os.devnull, 'w'))
+            if ret == 0:
+                return True
+            else:
+                return False
+        else:
+            logger.error("adb forward --list not supported; recommend to upgrade 1.0.31 or newer version")
+            return False
+
+    def get_adb_forwarded_port(self):
+        out = subprocess.check_output(['/usr/bin/adb version'], shell=True)
+        search = re.search('[0-9\.]+', out)
+        os.system("ANDROID_SERIAL=" + self.serial + " adb wait-for-device")
+        if search and search.group(0) >= '1.0.31':
+            forward_list = subprocess.check_output('/usr/bin/adb forward --list', shell=True).splitlines()
+            for out in forward_list:
+                search_serial = re.search('\w+', out)
+                if search_serial and search_serial.group(0) == self.serial:
+                    logger.info("DeviceSerial[" + self.serial + "] forwarded")
+                    return int(re.search(' tcp:(\d+) ', out).group(1))
+        else:
+            logger.info("adb forward --list not supported; recommend to upgrade 1.0.31 or newer version")
+        return None
+
+    def acquire_file_lock(self):
+        self.lock_file.acquire(timeout=60)
+        return self.lock_file.path
+
+    def release_file_lock(self):
+        try:
+            self.lock_file.release()
+        except NotLocked:
+            logger.info("Lock is released")
+        self.lock_file = None
+
+    def create_adb_forward(self, specify_port=None):
+        if self.is_in_forwarded_list():
+            self.adb_forwarded_port = self.get_adb_forwarded_port()
+            logger.info("Using existing port [" + str(self.adb_forwarded_port) + "]")
+            return True
+        if specify_port:
+            self.adb_forwarded_port = specify_port
+        else:
+            self.adb_forwarded_port = self._find_available_port()
+        if self.serial and self.adb_forwarded_port:
+            ret = os.system("ANDROID_SERIAL=" + self.serial + " adb forward tcp:" + str(self.adb_forwarded_port) + " tcp:2828")
+            if ret != 0:
+                raise DMError("can't forward port to ANDROID_SERIAL[" + self.serial + "]")
+        logger.info("Port forwarding success serial:[" + self.serial + "] port:[" + str(self.adb_forwarded_port) + "]")
+        return True
+
+    def remove_adb_forward(self):
+        # Remove port forwarding
+        ret = os.system("ADNDROID_SERIAL=" + self.serial + " adb forward --remove tcp:" + str(self.adb_forwarded_port))
+        if ret != 0:
+            raise DMError("can't forward port to ANDROID_SERIAL[" + self.serial + "]")
+
+
+class DevicePool(object):
+
+    serial_list = None
+    device_obj_map = None
+    current_device_object = None
+
+    def __init__(self, specify_serial=None):
+        self.serial_list = self._gen_serial_list()
+        self.device_obj_map = self._gen_device_obj_map()
+        if specify_serial and self.chk_serial_exist(specify_serial):
+            self.current_device_object.serial = self.device_obj_map[specify_serial]
+
+    def _gen_device_obj_map(self):
+        obj_map = {}
+        for serial in self.serial_list:
+            tmp_object = DeviceObject(serial)
+            if serial in obj_map.keys():
+                logging.error("Duplicate serial in serial list!!")
+            else:
+                obj_map[serial] = tmp_object
+        return obj_map
+
+    def _gen_serial_list(self):
+        # adb devices here
+        tmp_list = subprocess.check_output(['adb', 'devices']).splitlines()
+        tmp_list.pop(0)  # remove the description from adb
+        serial_list = map(lambda x: x.split("\t")[0], filter(lambda x: x, tmp_list))
+        return serial_list
+
+    def get_device(self):
+        if self.current_device_object:
+            logger.info("Use current device object instead of take new obj!")
+            return self.current_device_object
+        for serial_key in self.device_obj_map.keys():
             try:
-                if not self.lock_list[index].i_am_locking():
-                    self.lock_list[index].acquire(timeout=60)
-                    # successfully get lock, return lock.path
-                    self.my_lock = self.lock_list[index]
-                    self.current_lock_index = index
-                    return self.lock_list[index].path
+                if not self.device_obj_map[serial_key].is_file_locked() and not self.device_obj_map[serial_key].is_in_forwarded_list():
+                    self.device_obj_map[serial_key].acquire_file_lock()
+                    self.current_device_object = self.device_obj_map[serial_key]
+                    logger.info("Get device with serial [" + serial_key + "]!")
+                    return self.device_obj_map[serial_key]
             except:
                 # fail to get lock eventually, TODO: raise corresponding exception
                 logger.error("Failed to get lock!!")
                 pass
-        return None
-
-    def get_next_lock(self):
-        for next_index in range(self.current_lock_index + 1, len(self.lock_list)):
-            try:
-                if not self.lock_list[next_index].i_am_locking():
-                    self.lock_list[next_index].acquire(timeout=60)
-                    self.my_lock = self.lock_list[next_index]
-                    self.current_lock_index = next_index
-                    return self.lock_list[next_index].path
-            except:
-                logger.error("Failed to get lock!!")
-                pass
+        logger.warning("No available device.  Please retry after device released")
         return None
 
     def release(self):
-        if not self.my_lock:
-            logger.info("No lock acquired")
+        if not self.current_device_object:
+            logger.info("No device in use!")
             return
         try:
-            self.my_lock.release()
+            self.current_device_object.release_file_lock()
         except NotLocked:
-            logger.info("Lock is released")
-        self.my_lock = None
+            logger.info("File lock is released")
+
+        if self.current_device_object.is_in_forwarded_list:
+            # Remove port forwarding
+            self.current_device_object.remove_adb_forward()
+
+        self.current_device_object = None
+
+    def chk_device_is_forwarded(self, serial):
+        return self.device_obj_map[serial].is_in_forwarded_list()
+
+    def chk_device_is_file_locked(self, serial):
+        return self.device_obj_map[serial].is_file_locked()
+
+    def chk_serial_exist(self, serial):
+        chk_list = filter(lambda x: x == serial, self.serial_list)
+        if not chk_list:
+            logger.warning("Android serial[" + serial + "] can't be found")
+            return False
+        else:
+            return True
 
 
 if __name__ == '__main__':
     dp = DevicePool()
-    dp._device_list()
-    dp.get_lock()
-    dp._lock_list()
+    do = dp.get_device()
+    if do:
+        do.create_adb_forward()
     dp.release()


### PR DESCRIPTION
isolate the device object from device pool class, and attach all related attribute to device object instead of device pool,  and also modify the mtbf_job_runner correspond to this change
@zapion , @ypwalter r?